### PR TITLE
[update & docs] 주석/로그 변경 및 다음달과 이전달을 현재달에 표시하는 기능(반투명) 등

### DIFF
--- a/app/src/main/java/com/example/dayin/MainActivity.kt
+++ b/app/src/main/java/com/example/dayin/MainActivity.kt
@@ -2,26 +2,15 @@ package com.example.dayin
 
 import android.os.Bundle
 import android.util.Log
-import android.view.View
-import android.view.ViewGroup
-import android.widget.GridLayout
-import android.widget.TextView
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.recyclerview.widget.GridLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import androidx.viewpager2.widget.ViewPager2
 import com.example.dayin.databinding.ActivityMainBinding
 import com.example.dayin.fragments.DiaryFragment
 import com.example.dayin.fragments.MoneyFragment
 import com.example.dayin.fragments.ScheduleFragment
 import java.time.LocalDate
-import java.time.YearMonth
-import java.time.format.DateTimeFormatter
-import java.util.Locale
-import java.util.Calendar
 
 class MainActivity : AppCompatActivity() {
 

--- a/app/src/main/java/com/example/dayin/adapter/CalendarAdapter.kt
+++ b/app/src/main/java/com/example/dayin/adapter/CalendarAdapter.kt
@@ -1,16 +1,16 @@
 package com.example.dayin.adapter
 
+import android.graphics.Color
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-import com.example.dayin.MainActivity
 import com.example.dayin.R
 
 //CalendarFragment에서 사용
-class CalendarAdapter(private val dayList: ArrayList<String>, private val type: Int): RecyclerView.Adapter<CalendarAdapter.ItemViewHolder>() {
+class CalendarAdapter(private val dayList: ArrayList<Pair<String, Boolean>>, private val type: Int): RecyclerView.Adapter<CalendarAdapter.ItemViewHolder>() {
 
     class ItemViewHolder(itemView: View): RecyclerView.ViewHolder(itemView){
         val dayText: TextView = itemView.findViewById(R.id.dayText) //dayText id (calendar_item_s.xml, calendar_item_m.xml, calendar_item_d.xml choice one)
@@ -20,7 +20,7 @@ class CalendarAdapter(private val dayList: ArrayList<String>, private val type: 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemViewHolder {
 
         //CalendarFragment에서 전달 받은 layoutType 식별자 값에 따른 레이아웃 설정
-        var layout = when(type) {
+        val layout = when(type) {
             0 -> R.layout.calendar_item_s
             1 -> R.layout.calendar_item_m
             2 -> R.layout.calendar_item_d
@@ -42,14 +42,27 @@ class CalendarAdapter(private val dayList: ArrayList<String>, private val type: 
         val displayMetrics = parent.context.resources.displayMetrics
         val screenHeight = displayMetrics.heightPixels
 
+        var count = 7
+
+        if (itemCount / 7 == 6) {
+            count = 8
+        }
+
         Log.d("CalendarAdapter", "calculateMinHeightForItem complete")
         // 최소 높이 계산
-        return screenHeight / 8
+        return screenHeight / count
     }
 
     //데이터 설정 (리사이클러 뷰 아이템 날짜 text 설정)
     override fun onBindViewHolder(holder: ItemViewHolder, position: Int){
-        holder.dayText.text = dayList[holder.adapterPosition]
+        val (dayText, isOtherMonth) = dayList[holder.bindingAdapterPosition]
+        holder.dayText.text = dayText
+
+        if (isOtherMonth) {
+            holder.dayText.setTextColor(Color.parseColor("#80000000")) // 반투명
+        } else {
+            holder.dayText.setTextColor(Color.parseColor("#FF000000")) // 불투명
+        }
     }
 
     //데이터 리스트 사이즈 get 함수

--- a/app/src/main/java/com/example/dayin/adapter/CalendarPagerAdapter.kt
+++ b/app/src/main/java/com/example/dayin/adapter/CalendarPagerAdapter.kt
@@ -1,6 +1,5 @@
 package com.example.dayin.adapter
 
-import android.util.Log
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.example.dayin.fragments.CalendarFragment
@@ -14,7 +13,6 @@ class CalendarPagerAdapter(activity: FragmentActivity, private val startDate: Lo
 
     //페이지 수 get 함수
     override fun getItemCount(): Int {
-        Log.d("CalendarPagerAdapter", "getItemCount called")
         return Int.MAX_VALUE
     }
 

--- a/app/src/main/java/com/example/dayin/fragments/CalendarFragment.kt
+++ b/app/src/main/java/com/example/dayin/fragments/CalendarFragment.kt
@@ -54,24 +54,49 @@ class CalendarFragment : Fragment() {
     }
 
     //날짜 배열 생성 함수
-    private fun dayInMonthArray(date: LocalDate): ArrayList<String> {
-        val dayList = ArrayList<String>()
-        val yearMonth = YearMonth.from(date) //연도, 월
-        val lastDay = yearMonth.lengthOfMonth() //달의 마지막 날짜
-        val firstDay = date.withDayOfMonth(1) //달의 첫 날짜
-        val dayOfWeek = firstDay.dayOfWeek.value % 7 //첫 날의 요일 (일요일이 0)
+    private fun dayInMonthArray(date: LocalDate): ArrayList<Pair<String, Boolean>> {
+        val dayList = ArrayList<Pair<String, Boolean>>()
+        val yearMonth = YearMonth.from(date) // 연도, 월
+        val lastDay = yearMonth.lengthOfMonth() // 달의 마지막 날짜
+        val firstDay = date.withDayOfMonth(1) // 달의 첫 날짜
+        val dayOfWeek = firstDay.dayOfWeek.value % 7 // 첫 날의 요일 (일요일이 0)
 
-        //날짜 배열 생성
-        for (i in 0 until  42) {
-            if (i < dayOfWeek || i >= (lastDay + dayOfWeek)) {
-                dayList.add("")
-            } else {
-                dayList.add((i - dayOfWeek + 1).toString())
+        val prevMonth = yearMonth.minusMonths(1) //이전달
+        val nextMonth = yearMonth.plusMonths(1) //다음달
+        val prevLastDay = prevMonth.lengthOfMonth() //이전 달의 마지막 날
+
+        var lastNum: Int
+
+        if ((dayOfWeek == 5 && lastDay >= 31) || (dayOfWeek == 6 && lastDay >= 30)) {
+            lastNum = 42
+        } else {
+            lastNum = 35
+        }
+
+        for (i in 0 until lastNum) {
+            when {
+                i < dayOfWeek -> {
+                    // 이전 달의 날짜
+                    val day = prevLastDay - (dayOfWeek - i - 1)
+                    dayList.add(Pair(day.toString(), true))
+                }
+                i >= (lastDay + dayOfWeek) -> {
+                    // 다음 달의 날짜 (범위를 제한)
+                    val day = i - (lastDay + dayOfWeek) + 1
+                    if (day <= nextMonth.lengthOfMonth()) {
+                        dayList.add(Pair(day.toString(), true))
+                    }
+                }
+                else -> {
+                    // 현재 달의 날짜
+                    dayList.add(Pair((i - dayOfWeek + 1).toString(), false))
+                }
             }
         }
-        return dayList
         Log.d("CalendarFragment", "dayList create complete")
+        return dayList
     }
+
 
     //정적 멤버
     companion object {

--- a/app/src/main/java/com/example/dayin/fragments/MoneyFragment.kt
+++ b/app/src/main/java/com/example/dayin/fragments/MoneyFragment.kt
@@ -12,7 +12,6 @@ import com.example.dayin.MainActivity
 import com.example.dayin.R
 import com.example.dayin.adapter.CalendarPagerAdapter
 import com.example.dayin.databinding.FragmentMBinding
-import com.example.dayin.databinding.FragmentSBinding
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 


### PR DESCRIPTION
+ 현재 페이지 달력 화면에 다음 달과 이전 달을 빈 공간에 반투명으로 일부 표시하는 기능

+ 리사이클러 뷰 아이템들의 최소 높이 설정을 dayList의 길이를 조절하여 동적으로 설정